### PR TITLE
Automatic browser open to login

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ qstring = "0.7.2"
 
 url = { version = "2.2.1",  features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"]}
+
+webbrowser = "0.5.5"

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -65,11 +65,17 @@ fn get_token(auth_url: Url, token_url: Url) -> Result<BasicTokenResponse> {
         .url();
 
     // The URL the user should browse to, in order to trigger the authorization process.
-    // todo : open a browser automagically.
-    println!(
-        "\nTo authenticate with drogue cloud please browse to: \n{}",
-        final_auth_url
-    );
+    log::info!("Opening browser.");
+    match webbrowser::open(final_auth_url.as_str()) {
+        Err(_) => {
+            log::warn!("Failed to open browser.");
+            println!(
+                "\nTo authenticate with drogue cloud please browse to: \n{}",
+                final_auth_url
+            )
+        }
+        _ => (),
+    };
 
     let bind = format!("0.0.0.0:{}", SERVER_PORT);
     //start a local server


### PR DESCRIPTION
Fixes #28 

Used [webbrowser](https://crates.io/crates/webbrowser) to launch the browser.