### PR TITLE
Config management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,9 +372,11 @@ dependencies = [
  "log",
  "oauth2",
  "qstring",
+ "read_input",
  "reqwest 0.11.2",
  "serde",
  "serde_json",
+ "serde_yaml",
  "simple_logger",
  "strum",
  "strum_macros",
@@ -889,6 +891,12 @@ name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1470,6 +1478,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "read_input"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b57518cc6538a2eb7dce826e24fa51d0b7cf8e744ee10c7f56259cdec40050e5"
+
+[[package]]
 name = "redox_syscall"
 version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1708,6 +1722,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15654ed4ab61726bf918a39cb8d98a2e2995b002387807fa6ba58fdf7f59bb23"
+dependencies = [
+ "dtoa",
+ "linked-hash-map",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1774,15 +1800,15 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strum"
-version = "0.20.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
+checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
 
 [[package]]
 name = "strum_macros"
-version = "0.20.1"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
+checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2362,4 +2388,13 @@ checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 dependencies = [
  "winapi 0.2.8",
  "winapi-build",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,12 +21,15 @@ clap = "2.33.3"
 oauth2 = "3.0"
 
 simple_logger = "1.11.0"
-log = "0.4.14"
+log = "0.4.13"
 
-strum = "0.20"
-strum_macros = "0.20"
+read_input = "0.8.4"
+
+strum = "0.18"
+strum_macros = "0.18"
 
 serde_json = "1.0"
+serde_yaml = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 colored_json = "2"
 tempfile = "3.2.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ In order to use `drg` to manage resources in drogue cloud you first need to auth
 ```
 drg login https://drogue-cloud-registry-endpoint
 ```
-Then follow the steps to authenticate. drg will generate a config file to save your configuration.
+Then follow the steps to authenticate. drg will ask you to name this new context and generate a config file to save your configuration.
 
 ## Managing resources 
 
@@ -66,16 +66,39 @@ drg edit device <deviceId> -a <appId> -f </path/to/json>
 drg delete device <deviceId> - <appId>
 ```
 
-## Configuration fie
+## Configuration file
 
-`drg` will load cluster settings from a configuration file. The `DRGCFG` environment variable can point to a config file location.
-The default config file location is `$HOME/.config/drg_config.json`. This default value will be used if the environment variable is not set. 
+`drg` will load cluster settings from the default context of a configuration file. The `DRGCFG` environment variable can point to a config file location.
+The default config file location is `$HOME/.config/drg_config.yaml`. This default value will be used if the environment variable is not set. 
 This location can be overriden with the `--config` argument : 
 ```
 drg --config path/to/config create device <deviceId> --app <appId>
 ```
 
 To get a working config file, run see [login to a drogue cloud instance](#Log-in-to-a-drogue-cloud-instance)
+
+### Context management
+
+A valid configuration can contain multiple context allowing you to switch between cluster easily. 
+To create a new context simply log into a cluster with `drg login` : [login to a drogue cloud instance](#Log-in-to-a-drogue-cloud-instance)
+If it's the first context created for this configuration file it will be set as active by default. 
+
+To update the active context for a config file : 
+```
+drg context set-active <contextId>
+```
+
+Here are some other commads available to manage contexts :
+```
+drg context show #will display the whole config file. 
+drg context list
+drg context set-default-app <appId> #will use active context
+drg context set-default-app <appId> --context <anotherContextId>
+drg context delete <contextId> 
+drg context rename <contextId> <newContextId>
+```
+
+context and app can be set with environment variables : `DRG_CONTEXT` and `DRG_APP`.
 
 # Roadmap
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -165,7 +165,6 @@ impl Config {
             let ctx = self.get_context_as_mut(&name)?;
             ctx.rename(new_name.clone());
 
-
             if self.active_context == name {
                 self.active_context = new_name;
             }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,31 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context as AnyhowContext, Result};
 use serde::{Deserialize, Serialize};
 use std::{env, fs::create_dir_all, fs::write, fs::File, path::Path};
 
 use chrono::{DateTime, Utc};
 use oauth2::basic::BasicTokenResponse;
+use read_input::prelude::*;
 use url::Url;
+
+use crate::AppId;
+
+type ContextId = String;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Config {
+    pub active_context: ContextId,
+    pub contexts: Vec<Context>,
+    //todo : when loading, put a ref to the active context for faster access
+    // to avoid looping through the contexts each time.
+    // #[serde(skip)]
+    // active_ctx_ref: &Context
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Context {
+    pub name: ContextId,
     pub drogue_cloud_url: Url,
-    pub default_app: Option<String>,
+    pub default_app: Option<AppId>,
     pub auth_url: Url,
     pub token_url: Url,
     pub registry_url: Url,
@@ -17,26 +33,163 @@ pub struct Config {
     pub token: BasicTokenResponse,
 }
 
-pub fn load_config(path: Option<&str>) -> Result<Config> {
-    let path = eval_config_path(path);
-    log::info!("Loading configuration file: {}", path);
+impl Config {
+    pub fn empty() -> Config {
+        Config {
+            active_context: String::new(),
+            contexts: Vec::new(),
+        }
+    }
+    pub fn from(path: Option<&str>) -> Result<Config> {
+        let path = eval_config_path(path);
+        log::info!("Loading configuration file: {}", &path);
 
-    let file = File::open(path)
-        .context("Unable to open configuration file. Did you log into a drogue cloud cluster ?")?;
-    let config: Config = serde_json::from_reader(file).context("Invalid configuration file.")?;
-    Ok(config)
-}
+        let file = File::open(path).context(
+            "Unable to open configuration file. Did ou log into a drogue cloud cluster ?",
+        )?;
+        let config: Config =
+            serde_yaml::from_reader(file).context("Invalid configuration file.")?;
 
-pub fn save_config(config: &Config) -> Result<()> {
-    let path = eval_config_path(None);
-    log::info!("Saving config file: {}", path);
-
-    if let Some(parent) = Path::new(&path).parent() {
-        create_dir_all(parent).context("Failed to create parent directory of configuration")?;
+        Ok(config)
     }
 
-    write(&path, serde_json::to_string_pretty(&config)?)
-        .context(format!("Unable to write config file :{}", path))
+    pub fn add_context(&mut self, context: Context) -> Result<()> {
+        let name = &context.name;
+        if !self.contains_context(name) {
+            if self.contexts.is_empty() {
+                self.active_context = name.clone();
+            }
+            self.contexts.push(context);
+            Ok(())
+        } else {
+            Err(anyhow!("Context {} already exist in config!", name))
+        }
+    }
+
+    pub fn get_context(&self, name: &Option<ContextId>) -> Result<&Context> {
+        match name {
+            Some(n) => self.get_context_as_ref(n),
+            None => self.get_active_context(),
+        }
+    }
+
+    pub fn get_context_mut(&mut self, name: &Option<ContextId>) -> Result<&mut Context> {
+        match name {
+            Some(n) => self.get_context_as_mut(n),
+            None => self.get_active_context_mut(),
+        }
+    }
+    fn get_active_context(&self) -> Result<&Context> {
+        let default_context = &self.active_context;
+        self.get_context_as_ref(default_context)
+    }
+    fn get_active_context_mut(&mut self) -> Result<&mut Context> {
+        // todo : avoid the clone ?
+        let default_context = &self.active_context.clone();
+        self.get_context_as_mut(default_context)
+    }
+    fn get_context_as_ref(&self, name: &ContextId) -> Result<&Context> {
+        for c in &self.contexts {
+            if &c.name == name {
+                return Ok(c);
+            }
+        }
+        Err(anyhow!("Context \"{}\" not found in config file.", name))
+    }
+
+    fn get_context_as_mut(&mut self, name: &ContextId) -> Result<&mut Context> {
+        for c in &mut self.contexts {
+            if &c.name == name {
+                return Ok(c);
+            }
+        }
+        Err(anyhow!("Context \"{}\" not found in config file.", name))
+    }
+    fn contains_context(&self, name: &ContextId) -> bool {
+        for config in &self.contexts {
+            if &config.name == name {
+                return true;
+            }
+        }
+        false
+    }
+    pub fn list_contexts(&self) {
+        for config in &self.contexts {
+            println!("{}", &config.name)
+        }
+    }
+
+    pub fn set_active_context(&mut self, name: ContextId) -> Result<()> {
+        if self.contains_context(&name) {
+            log::error!("{} set as active context.", &name);
+            self.active_context = name;
+            Ok(())
+        } else {
+            Err(anyhow!("Context {} does not exist in config file.", name))
+        }
+    }
+
+    pub fn write(&self, path: Option<&str>) -> Result<()> {
+        let path = eval_config_path(path);
+        if let Some(parent) = Path::new(&path).parent() {
+            create_dir_all(parent).context("Failed to create parent directory of configuration")?;
+        }
+
+        log::info!("Saving config file: {}", &path);
+        write(&path, serde_yaml::to_string(&self)?)
+            .context(format!("Unable to write config file :{}", path))
+    }
+
+    pub fn delete_context(&mut self, name: &ContextId) -> Result<()> {
+        if self.contains_context(&name) {
+            self.contexts.retain(|c| &c.name != name);
+
+            if &self.active_context == name {
+                if self.contexts.len() > 0 {
+                    self.active_context = self.contexts[0].name.clone();
+                } else {
+                    self.active_context = String::new();
+                }
+            }
+            Ok(())
+        } else {
+            Err(anyhow!("Context {} does not exist in config file.", name))
+        }
+    }
+
+    // see fnOnce ?
+    // https://github.com/ctron/operator-framework/blob/e827775e023dfbe22a9defbf31e6a87f46d38ef5/src/install/container/env.rs#L259-L277
+
+    pub fn rename_context(&mut self, name: ContextId, new_name: ContextId) -> Result<()> {
+        if self.contains_context(&name) {
+            let ctx = self.get_context_as_mut(&name)?;
+            ctx.rename(new_name.clone());
+
+
+            if self.active_context == name {
+                self.active_context = new_name;
+            }
+            Ok(())
+        } else {
+            Err(anyhow!("Context {} does not exist in config file.", name))
+        }
+    }
+
+    //todo implement a display Trait ?
+    pub fn show(&self) -> Result<()> {
+        println!("{}", serde_yaml::to_string(&self)?);
+        Ok(())
+    }
+}
+
+impl Context {
+    fn rename(&mut self, new_name: ContextId) {
+        self.name = new_name;
+    }
+
+    pub fn set_default_app(&mut self, app: AppId) {
+        self.default_app = Some(app);
+    }
 }
 
 // use the provided config path or `$DRGCFG` value if set
@@ -49,7 +202,18 @@ fn eval_config_path(path: Option<&str>) -> String {
         None => env::var("DRGCFG").unwrap_or_else(|_| {
             let xdg = env::var("XDG_CONFIG_HOME")
                 .unwrap_or(format!("{}/.config", env::var("HOME").unwrap()));
-            format!("{}/drg_config.json", xdg)
+            format!("{}/drg_config.yaml", xdg)
         }),
     }
+}
+
+pub fn ask_config_name() -> ContextId {
+    input::<String>()
+        .msg("Context name: ")
+        .err("Invalid context name")
+        .add_err_test(
+            |s| !s.contains(" "),
+            "context name should not contains spaces",
+        )
+        .get()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,51 +5,127 @@ mod devices;
 mod openid;
 mod util;
 
-use arguments::{Other_commands, Parameters, Resources, Verbs};
+use arguments::{Context_subcommands, Other_commands, Parameters, Resources, Verbs};
 
-use anyhow::Result;
+use crate::config::Config;
+use anyhow::{Context as AnyhowContext, Result};
 use std::process::exit;
 use std::str::FromStr;
-type AppId = str;
-type DeviceId = str;
+
+type AppId = String;
+type DeviceId = String;
 
 fn main() -> Result<()> {
     let matches = arguments::parse_arguments();
-    let mut config;
+    let config_path = matches.value_of(Parameters::config);
+    let context_arg = matches.value_of(Parameters::context).map(|s| s.to_string());
 
     simple_logger::SimpleLogger::new()
         .with_level(util::log_level(&matches))
         .init()
         .unwrap();
 
+    // load the config file
+    let config_result: Result<Config> =
+        Config::from(config_path).context("Error loading config file");
+
     if matches.is_present(Other_commands::login) {
         let (_, submatches) = matches.subcommand();
         let url = util::url_validation(submatches.unwrap().value_of(Parameters::url).unwrap())?;
 
-        config = openid::login(url.clone())?;
+        let mut config = config_result.unwrap_or(Config::empty());
+        let context = openid::login(url.clone())?;
 
         println!("\nSuccessfully authenticated to drogue cloud : {}", url);
-        config::save_config(&config)?;
+        config.add_context(context)?;
+        config.write(config_path)?;
         exit(0);
     }
-
-    // load the config file
-    let rst_config = config::load_config(matches.value_of(Parameters::config));
 
     if matches.is_present(Other_commands::version) {
-        util::print_version(&rst_config);
+        util::print_version(&config_result);
         exit(0);
     }
 
-    config = rst_config?;
-
-    config = openid::verify_token_validity(config)?;
+    let mut config: Config = config_result?;
 
     if matches.is_present(Other_commands::token) {
-        openid::print_token(&config);
+        let context = config.get_context(&context_arg)?;
+        openid::print_token(&context);
         exit(0);
     }
 
+    if matches.is_present(Other_commands::context) {
+        match matches.subcommand() {
+            (_cmd_name, sub_cmd) => {
+                let cmd = sub_cmd.unwrap();
+                let (v, c) = cmd.subcommand();
+                let verb = Context_subcommands::from_str(v);
+
+                match verb? {
+                    Context_subcommands::create => {
+                        println!("To create a new context use drg login");
+                        exit(1);
+                    }
+                    Context_subcommands::list => {
+                        config.list_contexts();
+                        exit(0);
+                    }
+                    Context_subcommands::show => {
+                        config.show()?;
+                        exit(0);
+                    }
+                    Context_subcommands::set_active => {
+                        let id = c
+                            .unwrap()
+                            .value_of(Parameters::context_id)
+                            .unwrap()
+                            .to_string();
+                        config.set_active_context(id)?;
+                        config.write(config_path)?;
+                        exit(0);
+                    }
+                    Context_subcommands::delete => {
+                        let id = c
+                            .unwrap()
+                            .value_of(Parameters::context_id)
+                            .unwrap()
+                            .to_string();
+                        config.delete_context(&id)?;
+                        config.write(config_path)?;
+                        exit(0);
+                    }
+                    Context_subcommands::set_default_app => {
+                        let id = c.unwrap().value_of(Parameters::id).unwrap().to_string();
+                        let ctx_name = matches.value_of(Parameters::context).map(|s| s.to_string());
+
+                        let context = config.get_context_mut(&ctx_name)?;
+                        context.set_default_app(id);
+                        config.write(config_path)?;
+                        exit(0);
+                    }
+                    Context_subcommands::rename => {
+                        let ctx = c
+                            .unwrap()
+                            .value_of(Parameters::context_id)
+                            .unwrap()
+                            .to_string();
+                        let new_ctx = c.unwrap().value_of("new_context_id").unwrap().to_string();
+
+                        config.rename_context(ctx, new_ctx)?;
+                        config.write(config_path)?;
+                        exit(0);
+                    }
+                }
+            }
+        }
+    }
+
+    if openid::verify_token_validity(config.get_context_mut(&context_arg)?)? {
+        config.write(config_path)?;
+    }
+
+    let context = config.get_context(&context_arg)?;
     match matches.subcommand() {
         (cmd_name, sub_cmd) => {
             let verb = Verbs::from_str(cmd_name);
@@ -59,20 +135,25 @@ fn main() -> Result<()> {
                 Verbs::create => match cmd.subcommand() {
                     (res, command) => {
                         let data = util::json_parse(command.unwrap().value_of(Parameters::spec))?;
-                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+                        let id = command
+                            .unwrap()
+                            .value_of(Parameters::id)
+                            .unwrap()
+                            .to_string();
 
                         let resource = Resources::from_str(res);
 
                         match resource? {
-                            Resources::app => apps::create(&config, id, data)
+                            Resources::app => apps::create(&context, id, data)
                                 .map_err(|e| {
                                     log::error!("{:?}", e);
                                     exit(3)
                                 })
                                 .unwrap(),
                             Resources::device => {
-                                let app_id = arguments::get_app_id(&command.unwrap(), &config)?;
-                                devices::create(&config, id, data, app_id)
+                                let app_id =
+                                    arguments::get_app_id(&command.unwrap(), &context)?.to_string();
+                                devices::create(&context, id, data, app_id)
                                     .map_err(|e| {
                                         log::error!("{:?}", e);
                                         exit(3)
@@ -84,19 +165,24 @@ fn main() -> Result<()> {
                 },
                 Verbs::delete => match cmd.subcommand() {
                     (res, command) => {
-                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+                        let id = command
+                            .unwrap()
+                            .value_of(Parameters::id)
+                            .unwrap()
+                            .to_string();
                         let resource = Resources::from_str(res);
 
                         match resource? {
-                            Resources::app => apps::delete(&config, id)
+                            Resources::app => apps::delete(&context, id)
                                 .map_err(|e| {
                                     log::error!("{:?}", e);
                                     exit(3)
                                 })
                                 .unwrap(),
                             Resources::device => {
-                                let app_id = arguments::get_app_id(&command.unwrap(), &config)?;
-                                devices::delete(&config, app_id, id)
+                                let app_id =
+                                    arguments::get_app_id(&command.unwrap(), &context)?.to_string();
+                                devices::delete(&context, app_id, id)
                                     .map_err(|e| {
                                         log::error!("{:?}", e);
                                         exit(3)
@@ -108,20 +194,25 @@ fn main() -> Result<()> {
                 },
                 Verbs::edit => match cmd.subcommand() {
                     (res, command) => {
-                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+                        let id = command
+                            .unwrap()
+                            .value_of(Parameters::id)
+                            .unwrap()
+                            .to_string();
                         let file = command.unwrap().value_of(Parameters::filename);
                         let resource = Resources::from_str(res);
 
                         match resource? {
-                            Resources::app => apps::edit(&config, id, file)
+                            Resources::app => apps::edit(&context, id, file)
                                 .map_err(|e| {
                                     log::error!("{:?}", e);
                                     exit(3)
                                 })
                                 .unwrap(),
                             Resources::device => {
-                                let app_id = arguments::get_app_id(&command.unwrap(), &config)?;
-                                devices::edit(&config, app_id, id, file)
+                                let app_id =
+                                    arguments::get_app_id(&command.unwrap(), &context)?.to_string();
+                                devices::edit(&context, app_id, id, file)
                                     .map_err(|e| {
                                         log::error!("{:?}", e);
                                         exit(3)
@@ -133,20 +224,25 @@ fn main() -> Result<()> {
                 },
                 Verbs::get => match cmd.subcommand() {
                     (res, command) => {
-                        let id = command.unwrap().value_of(Parameters::id).unwrap();
+                        let id = command
+                            .unwrap()
+                            .value_of(Parameters::id)
+                            .unwrap()
+                            .to_string();
 
                         let resource = Resources::from_str(res);
 
                         match resource? {
-                            Resources::app => apps::read(&config, id)
+                            Resources::app => apps::read(&context, id)
                                 .map_err(|e| {
                                     log::error!("{:?}", e);
                                     exit(3)
                                 })
                                 .unwrap(),
                             Resources::device => {
-                                let app_id = arguments::get_app_id(&command.unwrap(), &config)?;
-                                devices::read(&config, app_id, id)
+                                let app_id =
+                                    arguments::get_app_id(&command.unwrap(), &context)?.to_string();
+                                devices::read(&context, app_id, id)
                                     .map_err(|e| {
                                         log::error!("{:?}", e);
                                         exit(3)

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::Verbs;
-use anyhow::{Context, Result};
+use anyhow::{Context as AnyhowContext, Result};
 use clap::crate_version;
 use clap::ArgMatches;
 use colored_json::write_colored_json;
@@ -105,15 +105,24 @@ pub fn print_version(config: &Result<Config>) {
     println!("Client Version: {}", VERSION);
 
     match config {
-        Ok(c) => {
-            let cloud_version = get_drogue_services_version(&c.drogue_cloud_url).unwrap();
-            println!("Connected drogue-cloud service: v{}", cloud_version);
+        Ok(cfg) => {
+            let context = cfg.get_context(&None);
+            match context {
+                Ok(ctx) => {
+                    let cloud_version = get_drogue_services_version(&ctx.drogue_cloud_url).unwrap();
+                    println!("Connected drogue-cloud service: v{}", cloud_version);
+                }
+                Err(e) => {
+                    println!("{}", e);
+                }
+            }
         }
-        Err(_) => {
+        Err(e) => {
             println!(
-                "Not connected to a drogue-cloud service. Compatible with v{}",
+                "Invalid configuration file. Compatible with v{}",
                 COMPATIBLE_DROGUE_VERSION
             );
+            log::info!("{}", e)
         }
     }
 


### PR DESCRIPTION
Some base work for multiple configs support and config managment. 

Note : `config ` and `context` subcommands are interchangeable.

Some usage examples  : 
```
drg config show
drg config list
drg config set-active <contextId>
drg config set-default-app <appId> #will use active context
drg config set-default-app <appId> --context <anotherContextId>
drg config delete <contextId> 

```
As always, config file path can be overidden with `--config` or `-C`



TODO : 

- [ ] rename a context
- [ ] open an interactive editor to edit the config file. 
