### PR TITLE
Added release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 name: Publish release
 jobs:
   release_linux:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Install build tools
         run: sudo apt-get update; DEBIAN_FRONTEND="noninteractive" sudo apt-get -y install build-essential curl tzdata 
@@ -20,10 +20,9 @@ jobs:
         with:
           command: build
           args: --release
-      - name: Rename
-        run: mv ./target/release/drg ./target/release/drg-linux
-      - uses: AButler/upload-release-assets@v2.0
-        with:
-          files: ./target/release/drg-linux
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: Upload release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mv ./target/release/drg drg-linux
+          hub release edit -m "" -a drg-linux ${GITHUB_REF/refs\/tags\//}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+on:
+  release:
+    branches:
+      - main
+    types: [created]
+name: Publish release
+jobs:
+  release_linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install build tools
+        run: sudo apt-get update; DEBIAN_FRONTEND="noninteractive" sudo apt-get -y install build-essential curl tzdata 
+      - name: Install openssl
+        run: sudo apt install -y libssl-dev pkg-config
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+      - name: Rename
+        run: mv ./target/release/drg ./target/release/drg-linux
+      - uses: AButler/upload-release-assets@v2.0
+        with:
+          files: ./target/release/drg-linux
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Fixes #43 

This GitHub action workflow runs at the time of release and uploads a `drg-linux` binary file compiled on **Ubuntu** to the release assets.