### PR TITLE
Removed timestamp on log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,7 +1752,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd57f17c093ead1d4a1499dc9acaafdd71240908d64775465543b8d9a9f1d198"
 dependencies = [
  "atty",
- "chrono",
  "colored",
  "log",
  "winapi 0.3.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ clap = "2.33.3"
 
 oauth2 = "3.0"
 
-simple_logger = "1.11.0"
+simple_logger = { version = "1.11.0", default-features = false, features = [ "colored" ] } 
 log = "0.4.13"
 
 read_input = "0.8.4"


### PR DESCRIPTION
Fixes #38 

Tweaked the `simple_logger` dependency to not include `chrono`.
Now we get the following output

![Selection_284](https://user-images.githubusercontent.com/43697446/116202821-a14beb80-a758-11eb-83b9-4cbde6bd384a.png)

