### PR TITLE
Replaced editor, config file location with cross-compile options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03d86534ed367a67548dc68113a0f5db55432fdfbb6e6f9d77704397d95d5780"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "drg"
 version = "0.4.1"
 dependencies = [
@@ -369,6 +389,8 @@ dependencies = [
  "chrono",
  "clap",
  "colored_json",
+ "dirs",
+ "edit",
  "log",
  "oauth2",
  "qstring",
@@ -391,6 +413,16 @@ name = "dtoa"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "edit"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdd6936f8bd9782e28932eef853bfcd8548992ce5748bb3e7e88bad613d0ee0"
+dependencies = [
+ "tempfile",
+ "which",
+]
 
 [[package]]
 name = "either"
@@ -1499,6 +1531,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+dependencies = [
+ "getrandom 0.2.2",
+ "redox_syscall 0.2.5",
+]
+
+[[package]]
 name = "regex"
 version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2362,16 @@ dependencies = [
  "web-sys",
  "widestring",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "which"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55551e42cbdf2ce2bedd2203d0cc08dba002c27510f86dab6d0ce304cba3dfe"
+dependencies = [
+ "either",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,6 @@ url = { version = "2.2.1",  features = ["serde"] }
 chrono = { version = "0.4", features = ["serde"]}
 
 webbrowser = "0.5.5"
+
+edit = "0.1.3"
+dirs = "3.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -201,7 +201,7 @@ fn eval_config_path(path: Option<&str>) -> String {
             let xdg = match config_dir() {
                 Some(path) => path.into_os_string().into_string().unwrap(),
                 None => {
-                    log::error!("Error accessing config file, please try using --filename");
+                    log::error!("Error accessing config file, please try using --config");
                     exit(1);
                 }
             };

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,12 +2,12 @@ use anyhow::{anyhow, Context as AnyhowContext, Result};
 use serde::{Deserialize, Serialize};
 use std::{env, fs::create_dir_all, fs::write, fs::File, path::Path};
 
+use crate::AppId;
 use chrono::{DateTime, Utc};
+use dirs::config_dir;
 use oauth2::basic::BasicTokenResponse;
 use read_input::prelude::*;
 use url::Url;
-
-use crate::AppId;
 
 type ContextId = String;
 
@@ -194,13 +194,14 @@ impl Context {
 // use the provided config path or `$DRGCFG` value if set
 // otherwise will default to $XDG_CONFIG_HOME
 // fall back to `$HOME/.config` if XDG var is not set.
-// todo crossplatform support
 fn eval_config_path(path: Option<&str>) -> String {
     match path {
         Some(p) => p.to_string(),
         None => env::var("DRGCFG").unwrap_or_else(|_| {
-            let xdg = env::var("XDG_CONFIG_HOME")
-                .unwrap_or(format!("{}/.config", env::var("HOME").unwrap()));
+            let xdg = match config_dir() {
+                Some(path) => path.into_os_string().into_string().unwrap(),
+                None => String::from("."),
+            };
             format!("{}/drg_config.yaml", xdg)
         }),
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context as AnyhowContext, Result};
 use serde::{Deserialize, Serialize};
-use std::{env, fs::create_dir_all, fs::write, fs::File, path::Path};
+use std::{env, fs::create_dir_all, fs::write, fs::File, path::Path, process::exit};
 
 use crate::AppId;
 use chrono::{DateTime, Utc};
@@ -200,7 +200,10 @@ fn eval_config_path(path: Option<&str>) -> String {
         None => env::var("DRGCFG").unwrap_or_else(|_| {
             let xdg = match config_dir() {
                 Some(path) => path.into_os_string().into_string().unwrap(),
-                None => String::from("."),
+                None => {
+                    log::error!("Error accessing config file, please try using --filename");
+                    exit(1);
+                }
             };
             format!("{}/drg_config.yaml", xdg)
         }),

--- a/src/util.rs
+++ b/src/util.rs
@@ -86,7 +86,10 @@ pub fn editor(original: String) -> Result<Value> {
     edit::edit_file(file.path())
         .map_err(|err| {
             log::debug!("{}", err);
-            log::error!("Error opening a text editor, please try using --filename");
+            log::error!(
+                "Error opening a text editor, please try using --filename with the following json"
+            );
+            show_json(&original);
             exit(1);
         })
         .unwrap();

--- a/src/util.rs
+++ b/src/util.rs
@@ -86,7 +86,7 @@ pub fn editor(original: String) -> Result<Value> {
     edit::edit_file(file.path())
         .map_err(|err| {
             log::debug!("{}", err);
-            log::error!("Error opening a text editor, pelase try --file");
+            log::error!("Error opening a text editor, please try using --filename");
             exit(1);
         })
         .unwrap();


### PR DESCRIPTION
Work in progress for #19 

- The XDG path specified to store the config file is calculated on the basis of the underlying OS using this crate - [dirs-rs](https://crates.io/crates/dirs)
- The editor required to use the "edit"  command is opened using this crate - [edit](https://crates.io/crates/edit)