### PR TITLE
Added primary trust anchor support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 
 # RPMs
 *.rpm
+
+*.pem
+*.crt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -457,7 +457,6 @@ dependencies = [
  "tiny_http",
  "url 2.2.1",
  "webbrowser",
- "webpki",
 ]
 
 [[package]]
@@ -2572,16 +2571,6 @@ dependencies = [
  "web-sys",
  "widestring",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28b2cd92db5cbd74e8e5028f7e27dd7aa3090e89e4f2a197cc7c8dfb69c7063b"
 
 [[package]]
+name = "arrayvec"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
 name = "ascii"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +114,18 @@ name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "bitvec"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8942c8d352ae1838c9dda0b0ca2ab657696ef2232a20147cf1b30ae1a9cb4321"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
 
 [[package]]
 name = "block-buffer"
@@ -353,6 +371,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "der-oid-macro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4cccf60bb98c0fca115a581f894aed0e43fa55bf289fdac5599bec440bb4fd6"
+dependencies = [
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "syn",
+]
+
+[[package]]
+name = "der-parser"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120842c2385dea19347e2f6e31caa5dced5ba8afdfacaac16c59465fdd1168f2"
+dependencies = [
+ "der-oid-macro",
+ "nom",
+ "num-bigint",
+ "num-traits",
+ "rusticata-macros",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +435,7 @@ name = "drg"
 version = "0.5.1"
 dependencies = [
  "anyhow",
+ "base64 0.13.0",
  "chrono",
  "clap",
  "colored_json",
@@ -394,6 +444,7 @@ dependencies = [
  "log",
  "oauth2",
  "qstring",
+ "rcgen",
  "reqwest 0.11.2",
  "serde",
  "serde_json",
@@ -406,6 +457,7 @@ dependencies = [
  "tiny_http",
  "url 2.2.1",
  "webbrowser",
+ "webpki",
 ]
 
 [[package]]
@@ -540,6 +592,12 @@ name = "fuchsia-zircon-sys"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+
+[[package]]
+name = "funty"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
@@ -919,6 +977,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lexical-core"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6607c62aa161d23d17a9072cc5da0be67cdfc89d3afb1e8d9c842bebc2525ffe"
+dependencies = [
+ "arrayvec",
+ "bitflags",
+ "cfg-if 1.0.0",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,12 +1155,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c5c51b9083a3c620fa67a2a635d1ce7d95b897e957d6b28ff9a5da960a103a6"
+dependencies = [
+ "bitvec",
+ "funty",
+ "lexical-core",
+ "memchr",
+ "version_check",
+]
+
+[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e0d047c1062aa51e256408c560894e5251f08925980e53cf1aa5bd00eec6512"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -1145,6 +1240,15 @@ name = "object"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
+
+[[package]]
+name = "oid-registry"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b26c042283b4ecc71edde70de2d6d0ab7e8743b8e7a7cb8467e4d153dfc7ad43"
+dependencies = [
+ "der-parser",
+]
 
 [[package]]
 name = "once_cell"
@@ -1215,6 +1319,17 @@ dependencies = [
  "rustc_version",
  "smallvec",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "pem"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
+dependencies = [
+ "base64 0.13.0",
+ "once_cell",
+ "regex",
 ]
 
 [[package]]
@@ -1312,6 +1427,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
 
 [[package]]
 name = "rand"
@@ -1501,6 +1622,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b4fc1b81d685fcd442a86da2e2c829d9e353142633a8159f42bf28e7e94428"
+dependencies = [
+ "chrono",
+ "pem",
+ "ring",
+ "x509-parser",
+ "yasna",
+]
+
+[[package]]
 name = "rdrand"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1628,6 +1762,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,6 +1790,21 @@ checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 dependencies = [
  "semver",
 ]
+
+[[package]]
+name = "rusticata-macros"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7390af60e66c44130b4c5ea85f2555b7ace835d73b4b889c704dc3cb4c0468c8"
+dependencies = [
+ "nom",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1819,6 +1983,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "string"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1884,6 +2060,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tempfile"
 version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1904,6 +2086,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2194,6 +2396,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2367,6 +2575,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "which"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2445,10 +2663,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "wyz"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "x509-parser"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64abca276c58f8341ddc13fd4bd6ae75993cc669043f5b34813c90f7dff04771"
+dependencies = [
+ "base64 0.13.0",
+ "chrono",
+ "data-encoding",
+ "der-parser",
+ "lazy_static",
+ "nom",
+ "oid-registry",
+ "ring",
+ "rusticata-macros",
+ "rustversion",
+ "thiserror",
+]
+
+[[package]]
 name = "yaml-rust"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "yasna"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+dependencies = [
+ "chrono",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,5 @@ dirs = "3.0"
 
 tabular = "0.1.4"
 
-webpki = "0.22.0"
 base64 = "0.13.0"
 rcgen = { version  = "0.8.11", features = ["pem", "x509-parser"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,7 @@ edit = "0.1.3"
 dirs = "3.0"
 
 tabular = "0.1.4"
+
+webpki = "0.22.0"
+base64 = "0.13.0"
+rcgen = { version  = "0.8.11", features = ["pem", "x509-parser"] }

--- a/README.md
+++ b/README.md
@@ -143,14 +143,21 @@ context and app can be set with environment variables : `DRG_CONTEXT` and `DRG_A
 
 ### Trust-anchor management
 
-Drogue cloud has support for authentication of devices using x509 certificates.
-To enable that we need to create a root CA and add it to the application object.
+x.509 certificates can be used to authenticate devices in Drogue Cloud. To do this, the application object needs
+to contain a root CA certificate, and the intended user must have its private key. This cert+key pair is used to sign
+device cert+key pair.
 
-    drg trust create --app <appId> --keyout <filename>
+    drg trust create --app <appId> --key-output <filename>
+
+Here, `--key-output` is the output file for root CA private key, and it needs to be saved and stored securely.
 
 Once Trust-anchor is set, we can use it to sign device certificates, for example:
 
-    drg trust add --app <appId> --device <deviceId> --CAkey <app-private-key> --out <filename> --keyout <filename>
+    drg trust add --app <appId> --device <deviceId> --ca-key <app-private-key> --out <filename> --key-output <filename>
+
+Here, `--ca-key` is the input file for root CA private key file.
+        `--out` is the output file for device certificate.
+        `--key-output` is the output file for device private key.
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -141,6 +141,17 @@ Here are some other commads available to manage contexts :
 
 context and app can be set with environment variables : `DRG_CONTEXT` and `DRG_APP`.
 
+### Trust-anchor management
+
+Drogue cloud has support for authentication of devices using x509 certificates.
+To enable that we need to create a root CA and add it to the application object.
+
+    drg trust create --app <appId> --keyout <filename>
+
+Once Trust-anchor is set, we can use it to sign device certificates, for example:
+
+    drg trust add --app <appId> --device <deviceId> --CAkey <app-private-key> --out <filename> --keyout <filename>
+
 # Roadmap
 
 In no particular order here are the following things that we would like to add to `drg` :

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -136,7 +136,12 @@ fn get(config: &Context, app: &str) -> Result<Response> {
         .context("Can't retrieve app data.")
 }
 
-pub fn add_trust_anchor(config: &Context, app: &str, keyout: Option<&str>) -> Result<()> {
+pub fn add_trust_anchor(
+    config: &Context,
+    app: &str,
+    keyout: Option<&str>,
+    days: i64,
+) -> Result<()> {
     let res = get(config, &app);
     match res {
         Ok(r) => match r.status() {
@@ -146,7 +151,7 @@ pub fn add_trust_anchor(config: &Context, app: &str, keyout: Option<&str>) -> Re
 
                 let body = json!({
                     "metadata": metadata["metadata"],
-                    "spec": trust::create_trust_anchor(app, keyout)
+                    "spec": trust::create_trust_anchor(app, keyout, days)
                 });
 
                 put(config, app, body)

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -152,7 +152,7 @@ pub fn add_trust_anchor(
                 // Todo : use json_value_merge
                 let body = json!({
                     "metadata": device_obj["metadata"],
-                    "spec": trust::create_trust_anchor(app, keyout, days)
+                    "spec": trust::create_trust_anchor(app, keyout, days)?
                 });
 
                 put(config, app, body)

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -136,7 +136,7 @@ fn get(config: &Context, app: &str) -> Result<Response> {
         .context("Can't retrieve app data.")
 }
 
-pub fn add_trust_anchor(config: &Context, app: &str, keyout: &str) -> Result<()> {
+pub fn add_trust_anchor(config: &Context, app: &str, keyout: Option<&str>) -> Result<()> {
     let res = get(config, &app);
     match res {
         Ok(r) => match r.status() {

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -37,8 +37,10 @@ pub enum Parameters {
     keep_current,
     labels,
     context_name,
-    keyout,
-    CAkey,
+    #[strum(serialize = "key-output")]
+    key_output,
+    #[strum(serialize = "ca-key")]
+    ca_key,
     out,
     days,
 }
@@ -156,11 +158,11 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .multiple(true)
         .help("A comma separated list of the label filters to filter the list with.");
 
-    let keyout = Arg::with_name(&Parameters::keyout.as_ref())
+    let keyout = Arg::with_name(&Parameters::key_output.as_ref())
         .takes_value(true)
         .required(false)
-        .long(Parameters::keyout.as_ref())
-        .help("Private key used to sign the trust-anchor and device certificates.");
+        .long(Parameters::key_output.as_ref())
+        .help("Output file containing the private key. Later to be used to sign device certificates, or device authentication.");
 
     let device_id_arg = Arg::with_name(&Resources::device.as_ref())
         .short("d")
@@ -169,8 +171,8 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .takes_value(true)
         .help("Device id");
 
-    let ca_key = Arg::with_name(&Parameters::CAkey.as_ref())
-        .long(&Parameters::CAkey.as_ref())
+    let ca_key = Arg::with_name(&Parameters::ca_key.as_ref())
+        .long(&Parameters::ca_key.as_ref())
         .takes_value(true)
         .required(true)
         .help("Private key of the CA i.e application.");
@@ -187,8 +189,11 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .takes_value(true)
         .required(false)
         .default_value("365")
-        .validator(util::is_number)
-        .help("Number of days the certificate should be valid.");
+        .help("Number of days the certificate should be valid for.")
+        .validator(|n| match n.parse::<u64>() {
+            Err(_) => Err(String::from("The value is not an integer")),
+            Ok(_) => Ok(()),
+        });
 
     App::new("Drogue Command Line Tool")
         .version(util::VERSION)

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -40,6 +40,7 @@ pub enum Parameters {
     keyout,
     CAkey,
     out,
+    days,
 }
 
 #[derive(AsRefStr, EnumString)]
@@ -180,6 +181,14 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .takes_value(true)
         .required(false)
         .help("Output device certificate to file.");
+
+    let cert_valid_days = Arg::with_name(&Parameters::days.as_ref())
+        .long(&Parameters::days.as_ref())
+        .takes_value(true)
+        .required(false)
+        .default_value("365")
+        .validator(util::is_number)
+        .help("Number of days the certificate should be valid.");
 
     App::new("Drogue Command Line Tool")
         .version(util::VERSION)
@@ -356,7 +365,8 @@ pub fn parse_arguments() -> ArgMatches<'static> {
                     SubCommand::with_name(Trust_subcommands::create.as_ref())
                         .about("Create a trust-anchor for an application.")
                         .arg(&app_id_arg)
-                        .arg(&keyout),
+                        .arg(&keyout)
+                        .arg(&cert_valid_days),
                 )
                 .subcommand(
                     SubCommand::with_name(Trust_subcommands::add.as_ref())
@@ -365,7 +375,8 @@ pub fn parse_arguments() -> ArgMatches<'static> {
                         .arg(&device_id_arg)
                         .arg(&ca_key)
                         .arg(&cert_out)
-                        .arg(&keyout),
+                        .arg(&keyout)
+                        .arg(&cert_valid_days),
                 ),
         )
         .get_matches()

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -184,12 +184,12 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .required(false)
         .help("Output device certificate to file.");
 
+    // Default value comes from trust::CERT_VALIDITY_DAYS
     let cert_valid_days = Arg::with_name(&Parameters::days.as_ref())
         .long(&Parameters::days.as_ref())
         .takes_value(true)
         .required(false)
-        .default_value("365")
-        .help("Number of days the certificate should be valid for.")
+        .help("Number of days the certificate should be valid for. [default: 365]")
         .validator(|n| match n.parse::<u64>() {
             Err(_) => Err(String::from("The value is not an integer")),
             Ok(_) => Ok(()),

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -157,7 +157,7 @@ pub fn parse_arguments() -> ArgMatches<'static> {
 
     let keyout = Arg::with_name(&Parameters::keyout.as_ref())
         .takes_value(true)
-        .required(true)
+        .required(false)
         .long(Parameters::keyout.as_ref())
         .help("Private key used to sign the trust-anchor and device certificates.");
 
@@ -178,8 +178,8 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .long(&Parameters::out.as_ref())
         .short("o")
         .takes_value(true)
-        .required(true)
-        .help("Output device certificate");
+        .required(false)
+        .help("Output device certificate to file.");
 
     App::new("Drogue Command Line Tool")
         .version(util::VERSION)
@@ -350,17 +350,17 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         )
         .subcommand(
             SubCommand::with_name(Other_commands::trust.as_ref())
-                .about("Manage trust anchors and device certificates.")
+                .about("Manage trust-anchors and device certificates.")
                 .setting(AppSettings::ArgRequiredElseHelp)
                 .subcommand(
                     SubCommand::with_name(Trust_subcommands::create.as_ref())
-                        .about("Create a trust anchor for an application. Defaults to rsa::4096")
+                        .about("Create a trust-anchor for an application.")
                         .arg(&app_id_arg)
                         .arg(&keyout),
                 )
                 .subcommand(
                     SubCommand::with_name(Trust_subcommands::add.as_ref())
-                        .about("Signs device certificate using application private key.")
+                        .about("Signs device certificate using application's private key.")
                         .arg(&app_id_arg)
                         .arg(&device_id_arg)
                         .arg(&ca_key)

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,10 +132,7 @@ fn main() -> Result<()> {
         let (v, command) = submatches.unwrap().subcommand();
         let verb = Trust_subcommands::from_str(v);
         let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
-        let days: i64 = match command.unwrap().value_of(&Parameters::days) {
-            Some(d) => d.parse().unwrap(),
-            _ => trust::CERT_VALIDITY_DAYS,
-        };
+        let days = command.unwrap().value_of(&Parameters::days);
 
         match verb? {
             Trust_subcommands::create => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -132,16 +132,14 @@ fn main() -> Result<()> {
         let (v, command) = submatches.unwrap().subcommand();
         let verb = Trust_subcommands::from_str(v);
         let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
+        let days: i64 = match command.unwrap().value_of(&Parameters::days) {
+            Some(d) => d.parse().unwrap(),
+            _ => trust::CERT_VALIDITY_DAYS,
+        };
 
         match verb? {
             Trust_subcommands::create => {
                 let keyout = command.unwrap().value_of(&Parameters::key_output);
-                let days: i64 = command
-                    .unwrap()
-                    .value_of(&Parameters::days)
-                    .unwrap()
-                    .parse()
-                    .unwrap();
                 apps::add_trust_anchor(&context, &app_id, keyout, days)
             }
             Trust_subcommands::add => {
@@ -160,13 +158,6 @@ fn main() -> Result<()> {
                 let device_cert = command.unwrap().value_of(&Parameters::out);
 
                 let device_key = command.unwrap().value_of(&Parameters::key_output);
-
-                let days: i64 = command
-                    .unwrap()
-                    .value_of(&Parameters::days)
-                    .unwrap()
-                    .parse()
-                    .unwrap();
 
                 let cert = apps::get_trust_anchor(&context, &app_id)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,11 +131,11 @@ fn main() -> Result<()> {
     if command == Other_commands::trust.as_ref() {
         let (v, command) = submatches.unwrap().subcommand();
         let verb = Trust_subcommands::from_str(v);
+        let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
 
         match verb? {
             Trust_subcommands::create => {
-                let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
-                let keyout = command.unwrap().value_of(&Parameters::keyout);
+                let keyout = command.unwrap().value_of(&Parameters::key_output);
                 let days: i64 = command
                     .unwrap()
                     .value_of(&Parameters::days)
@@ -145,12 +145,9 @@ fn main() -> Result<()> {
                 apps::add_trust_anchor(&context, &app_id, keyout, days)
             }
             Trust_subcommands::add => {
-                let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
-                let cert = apps::get_trust_anchor(&context, &app_id)?;
-
                 let ca_key = &command
                     .unwrap()
-                    .value_of(&Parameters::CAkey)
+                    .value_of(&Parameters::ca_key)
                     .unwrap()
                     .to_string();
 
@@ -162,7 +159,7 @@ fn main() -> Result<()> {
 
                 let device_cert = command.unwrap().value_of(&Parameters::out);
 
-                let device_key = command.unwrap().value_of(&Parameters::keyout);
+                let device_key = command.unwrap().value_of(&Parameters::key_output);
 
                 let days: i64 = command
                     .unwrap()
@@ -171,16 +168,17 @@ fn main() -> Result<()> {
                     .parse()
                     .unwrap();
 
+                let cert = apps::get_trust_anchor(&context, &app_id)?;
+
                 trust::create_device_certificate(
+                    &app_id,
                     &device_id,
                     ca_key,
                     &cert,
                     device_key,
                     device_cert,
                     days,
-                );
-
-                Ok(())
+                )
             }
         }?;
         exit(0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,11 +146,13 @@ fn main() -> Result<()> {
                     .unwrap()
                     .to_string();
 
-                let device_id = &command
+                let device_name = &command
                     .unwrap()
                     .value_of(&Resources::device)
                     .unwrap()
                     .to_string();
+
+                let device_id = trust::validate_device_name(&device_name, &app_id)?;
 
                 let device_cert = command.unwrap().value_of(&Parameters::out);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,16 +135,13 @@ fn main() -> Result<()> {
         match verb? {
             Trust_subcommands::create => {
                 let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
-                let keyout = &command
-                    .unwrap()
-                    .value_of(&Parameters::keyout)
-                    .unwrap()
-                    .to_string();
-                apps::add_trust_anchor(&context, &app_id, &keyout)
+                let keyout = command.unwrap().value_of(&Parameters::keyout);
+                apps::add_trust_anchor(&context, &app_id, keyout)
             }
             Trust_subcommands::add => {
                 let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
                 let cert = apps::get_trust_anchor(&context, &app_id)?;
+
                 let ca_key = &command
                     .unwrap()
                     .value_of(&Parameters::CAkey)
@@ -157,16 +154,10 @@ fn main() -> Result<()> {
                     .unwrap()
                     .to_string();
 
-                let device_cert = &command
-                    .unwrap()
-                    .value_of(&Parameters::out)
-                    .unwrap()
-                    .to_string();
-                let device_key = &command
-                    .unwrap()
-                    .value_of(&Parameters::keyout)
-                    .unwrap()
-                    .to_string();
+                let device_cert = command.unwrap().value_of(&Parameters::out);
+
+                let device_key = command.unwrap().value_of(&Parameters::keyout);
+
                 trust::create_device_certificate(
                     &device_id,
                     ca_key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,7 +136,13 @@ fn main() -> Result<()> {
             Trust_subcommands::create => {
                 let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
                 let keyout = command.unwrap().value_of(&Parameters::keyout);
-                apps::add_trust_anchor(&context, &app_id, keyout)
+                let days: i64 = command
+                    .unwrap()
+                    .value_of(&Parameters::days)
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+                apps::add_trust_anchor(&context, &app_id, keyout, days)
             }
             Trust_subcommands::add => {
                 let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
@@ -158,12 +164,20 @@ fn main() -> Result<()> {
 
                 let device_key = command.unwrap().value_of(&Parameters::keyout);
 
+                let days: i64 = command
+                    .unwrap()
+                    .value_of(&Parameters::days)
+                    .unwrap()
+                    .parse()
+                    .unwrap();
+
                 trust::create_device_certificate(
                     &device_id,
                     ca_key,
                     &cert,
                     device_key,
                     device_cert,
+                    days,
                 );
 
                 Ok(())

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -127,7 +127,7 @@ pub fn create_device_certificate(
     };
 
     match cert_key {
-        Some(file_name) => write_to_file(file_name, &csr),
+        Some(file_name) => write_to_file(file_name, &deivce_temp.certificate.serialize_private_key_pem()),
         _ => println!("{}", &deivce_temp.certificate.serialize_private_key_pem()),
     };
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -21,10 +21,10 @@ struct cert {
 }
 
 impl cert {
-    fn get_certificate(cert_type: CertificateType, comman_name: &str) -> Self {
+    fn get_certificate(cert_type: CertificateType, comman_name: &str, days: i64) -> Self {
         let mut params = CertificateParams::new(vec!["Drogue Iot".to_owned()]);
         params.not_before = Utc::now();
-        params.not_after = Utc::now() + Duration::days(365);
+        params.not_after = Utc::now() + Duration::days(days);
         params
             .distinguished_name
             .push(DnType::OrganizationName, "Drogue IoT".to_owned());
@@ -56,8 +56,8 @@ impl cert {
     }
 }
 
-pub fn create_trust_anchor(app_id: &str, keyout: Option<&str>) -> Value {
-    let app_certificate = cert::get_certificate(CertificateType::app, app_id);
+pub fn create_trust_anchor(app_id: &str, keyout: Option<&str>, days: i64) -> Value {
+    let app_certificate = cert::get_certificate(CertificateType::app, app_id, days);
 
     let pem_cert = &app_certificate.certificate.serialize_pem().unwrap();
     log::debug!("Self-signed certificate generated.");
@@ -88,6 +88,7 @@ pub fn create_device_certificate(
     ca_cert: &str,
     cert_key: Option<&str>,
     cert_out: Option<&str>,
+    days: i64,
 ) {
     let ca_key_content: KeyPair;
 
@@ -111,7 +112,7 @@ pub fn create_device_certificate(
         })
         .unwrap();
 
-    let deivce_temp = cert::get_certificate(CertificateType::device, &device_id);
+    let deivce_temp = cert::get_certificate(CertificateType::device, &device_id, days);
     let ca_cert_fin = Certificate::from_params(ca_certificate).unwrap();
 
     // Signing the device certificate with CA

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -144,6 +144,26 @@ pub fn create_device_certificate(
     Ok(())
 }
 
+pub fn validate_device_name(device_name: &str, app_id: &str) -> Result<String> {
+    let subject: Vec<&str> = device_name.split(", ").collect();
+
+    if subject.len() != 3 {
+        return Err(anyhow!(
+            "Invalid format: should be CN=<deviceID>, O=Drogue IoT, OU=<appID>"
+        ));
+    } else if !subject[0].starts_with("CN=") || subject[0] == "CN=" {
+        return Err(anyhow!("Invalid format: incorrect Comman name (CN)"));
+    } else if subject[1] != "O=Drogue IoT" {
+        return Err(anyhow!("Invalid format: incorrect Organization name (O)"));
+    } else if subject[2] != format!("OU={}", app_id) {
+        return Err(anyhow!(
+            "Invalid format: incorrect Organization Unit name. (OU)"
+        ));
+    }
+
+    Ok(subject[0].replace("CN=", ""))
+}
+
 fn write_to_file(file_name: &str, content: &str, resource_type: &str) {
     let mut file = File::create(file_name);
     match file.as_mut() {

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -127,7 +127,10 @@ pub fn create_device_certificate(
     };
 
     match cert_key {
-        Some(file_name) => write_to_file(file_name, &deivce_temp.certificate.serialize_private_key_pem()),
+        Some(file_name) => write_to_file(
+            file_name,
+            &deivce_temp.certificate.serialize_private_key_pem(),
+        ),
         _ => println!("{}", &deivce_temp.certificate.serialize_private_key_pem()),
     };
 }

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,0 +1,166 @@
+use base64::encode;
+use chrono::{Duration, Utc};
+use rcgen::{
+    BasicConstraints, Certificate, CertificateParams, CertificateSigningRequest, CustomExtension,
+    DnType, ExtendedKeyUsagePurpose, IsCa, KeyIdMethod, KeyPair,
+};
+use serde_json::{json, Value};
+use std::fs::File;
+use std::io::Write;
+use std::{fs, process::exit, str::from_utf8};
+
+#[allow(non_camel_case_types)]
+struct cert {
+    certificate: Certificate,
+}
+
+impl cert {
+    fn get_certificate(params: CertificateParams) -> Self {
+        Self {
+            certificate: Certificate::from_params(params).unwrap(),
+        }
+    }
+}
+
+pub fn create_trust_anchor(app: &str, keyout: &str) -> Value {
+    let mut params = CertificateParams::new(vec!["Drogue IoT".to_string()]);
+    params.is_ca = IsCa::Ca(BasicConstraints::Unconstrained);
+    params.not_before = Utc::now();
+    params.not_after = Utc::now() + Duration::days(365);
+    params
+        .distinguished_name
+        .push(DnType::OrganizationName, "Drogue IoT".to_owned());
+    params
+        .distinguished_name
+        .push(DnType::CommonName, &app.to_owned());
+    params
+        .distinguished_name
+        .push(DnType::OrganizationalUnitName, "Cloud".to_owned());
+
+    let app_certificate = cert::get_certificate(params);
+
+    let pem_cert = &app_certificate.certificate.serialize_pem().unwrap();
+    log::debug!("Self-signed certificate generated.");
+
+    let private_key = &app_certificate.certificate.serialize_private_key_pem();
+    log::debug!("Private key extracted.");
+
+    let mut app_key_file = File::create(keyout);
+    match app_key_file.as_mut() {
+        Ok(file) => match file.write_all(&private_key.as_bytes()) {
+            Ok(_) => {
+                log::debug!("Key exported to file")
+            }
+            Err(_) => {
+                log::error!("Error writing key to file.")
+            }
+        },
+        Err(e) => {
+            log::error!("Error opening the file. {}", e)
+        }
+    };
+
+    json!({
+        "trustAnchors": {
+            "anchors": [
+                {
+                    "certificate": encode(pem_cert)
+                }
+            ]
+        }
+    })
+}
+
+pub fn create_device_certificate(
+    device_id: &str,
+    ca_key: &str,
+    ca_cert: &str,
+    cert_key: &str,
+    cert_out: &str,
+) {
+    let ca_key_content: KeyPair;
+
+    match fs::read_to_string(ca_key) {
+        Ok(s) => match KeyPair::from_pem(&s.to_string()) {
+            Ok(s) => {
+                ca_key_content = s;
+            }
+            Err(e) => {
+                log::error!("Error reading CA key file. {}", e);
+                exit(1);
+            }
+        },
+        Err(_) => {
+            log::error!("Error reading CA key file.");
+            exit(1);
+        }
+    };
+
+    let ca_base64 = base64::decode(&ca_cert).unwrap();
+    let ca_cert_pem = from_utf8(&ca_base64).unwrap();
+    let ca_certificate = CertificateParams::from_ca_cert_pem(&ca_cert_pem, ca_key_content)
+        .map_err(|e| {
+            log::error!("Error: {}", e);
+            exit(1);
+        })
+        .unwrap();
+
+    let mut params = CertificateParams::new(vec![device_id.to_owned()]);
+    params.is_ca = IsCa::SelfSignedOnly;
+    params.not_before = Utc::now();
+    params.not_after = Utc::now() + Duration::days(365);
+    params
+        .distinguished_name
+        .push(DnType::OrganizationName, "Drogue IoT".to_owned());
+    params
+        .distinguished_name
+        .push(DnType::CommonName, &device_id.to_owned());
+    params
+        .distinguished_name
+        .push(DnType::OrganizationalUnitName, "Cloud".to_owned());
+
+    // const OID_EXT_KEY_USAGE :&[u64] = &[2, 5, 29, 15];
+    // const DIGITAL_SIGNATURE: &[u8] = &[2, 5, 29, 15, 4];
+
+    // params.custom_extensions.push(CustomExtension::from_oid_content(OID_EXT_KEY_USAGE, DIGITAL_SIGNATURE.to_vec()));
+    // params.custom_extensions.push(CustomExtension::from_oid_content(OID_EXT_KEY_USAGE, KEY_AGREEMENT.to_vec()));
+    params
+        .extended_key_usages
+        .push(ExtendedKeyUsagePurpose::ServerAuth);
+    params
+        .extended_key_usages
+        .push(ExtendedKeyUsagePurpose::ClientAuth);
+
+    params.key_identifier_method = KeyIdMethod::Sha256;
+
+    let deivce_temp = cert::get_certificate(params);
+    let ca_cert_fin = cert::get_certificate(ca_certificate);
+
+    let csr = deivce_temp
+        .certificate
+        .serialize_pem_with_signer(&ca_cert_fin.certificate)
+        .unwrap();
+
+    write(cert_out, &csr);
+    write(
+        cert_key,
+        &deivce_temp.certificate.serialize_private_key_pem(),
+    );
+}
+
+fn write(file_name: &str, content: &str) {
+    let mut app_key_file = File::create(file_name);
+    match app_key_file.as_mut() {
+        Ok(file) => match file.write_all(&content.as_bytes()) {
+            Ok(_) => {
+                log::debug!("File created. ")
+            }
+            Err(_) => {
+                log::error!("Error writing to file.")
+            }
+        },
+        Err(e) => {
+            log::error!("Error opening the file. {}", e)
+        }
+    };
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -254,12 +254,3 @@ pub fn age(str_timestamp: &str) -> Result<String> {
         Ok(format!("{}s", age.num_seconds()))
     }
 }
-
-pub fn is_number(str: String) -> Result<(), String> {
-    for s in str.chars() {
-        if !s.is_numeric() {
-            return Err(String::from("The value is not an integer"));
-        }
-    }
-    Ok(())
-}

--- a/src/util.rs
+++ b/src/util.rs
@@ -254,3 +254,12 @@ pub fn age(str_timestamp: &str) -> Result<String> {
         Ok(format!("{}s", age.num_seconds()))
     }
 }
+
+pub fn is_number(str: String) -> Result<(), String> {
+    for s in str.chars() {
+        if !s.is_numeric() {
+            return Err(String::from("The value is not an integer"));
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
I have worked on adding support for trust anchors in DRG using `rcgen` crate

Commands I have implemented

`drg trust create --app app12 --key-output app-private.key` => This adds the trust anchor to the application object and exports the private key.

`drg trust add --app app12 --device d7 --out device-cert.pem --key-output device-key.pem --ca-key app-private.key` 
This command takes in the application's private key and downloads the trust anchor. This is used to sign a CSR and finally outputs device-cert.pem and device-key.pem

`--days <number>` can also be specified for both the commands.
`--key-output` and `--out` are not mandatory, the certificate and key would be printed to console if not specified.