### PR TITLE
Added ca key verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,6 +458,7 @@ dependencies = [
  "tiny_http",
  "url 2.2.1",
  "webbrowser",
+ "x509-parser",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,4 +47,5 @@ tabular = "0.1.4"
 
 base64 = "0.13.0"
 rcgen = { version  = "0.8.11", features = ["pem", "x509-parser"] }
+x509-parser = "0.9.2"
 json_value_merge = "0.1.2"

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -118,6 +118,9 @@ pub fn create_device_certificate(
     let device_csr = generate_certificate(CertificateType::device, &device_id, &app_id, days)?;
     let ca_cert_fin = Certificate::from_params(ca_certificate)?;
 
+    // Checking equality of public keys of Cert from application object and supplied CA key
+    verify_public_key(ca_cert_pem, &ca_cert_fin.serialize_der()?)?;
+
     // Signing the device certificate with CA
     let device_cert = device_csr.serialize_pem_with_signer(&ca_cert_fin)?;
 
@@ -142,6 +145,29 @@ pub fn create_device_certificate(
     };
 
     Ok(())
+}
+
+fn verify_public_key(ca_cert: &str, local_cert: &[u8]) -> Result<()> {
+    let ca_x509 = x509_parser::pem::parse_x509_pem(&ca_cert.as_bytes())?.1;
+    let ca_x509_der = x509_parser::parse_x509_certificate(&ca_x509.contents)?.1;
+
+    let local_certificate = x509_parser::parse_x509_certificate(&local_cert)?.1;
+
+    let ca_public_key = ca_x509_der
+        .tbs_certificate
+        .subject_pki
+        .subject_public_key
+        .data;
+    let local_public_key = local_certificate
+        .tbs_certificate
+        .subject_pki
+        .subject_public_key
+        .data;
+
+    match ca_public_key.eq(local_public_key) {
+        false => Err(anyhow!("Wrong CA key")),
+        _ => Ok(()),
+    }
 }
 
 fn write_to_file(file_name: &str, content: &str, resource_type: &str) {

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -115,11 +115,12 @@ pub fn create_device_certificate(
     let ca_certificate = CertificateParams::from_ca_cert_pem(&ca_cert_pem, ca_key_content)
         .map_err(|e| anyhow!("Error: {}", e))?;
 
-    let device_csr = generate_certificate(CertificateType::device, &device_id, &app_id, days)?;
     let ca_cert_fin = Certificate::from_params(ca_certificate)?;
 
     // Checking equality of public keys of Cert from application object and supplied CA key
     verify_public_key(ca_cert_pem, &ca_cert_fin.serialize_der()?)?;
+
+    let device_csr = generate_certificate(CertificateType::device, &device_id, &app_id, days)?;
 
     // Signing the device certificate with CA
     let device_cert = device_csr.serialize_pem_with_signer(&ca_cert_fin)?;
@@ -164,10 +165,12 @@ fn verify_public_key(ca_cert: &str, local_cert: &[u8]) -> Result<()> {
         .subject_public_key
         .data;
 
-    match ca_public_key.eq(local_public_key) {
-        false => Err(anyhow!("Wrong CA key")),
-        _ => Ok(()),
-    }
+    ca_public_key
+        .eq(local_public_key)
+        .then(|| ())
+        .ok_or(anyhow!(
+            "Invalid CA key: trust anchor and private key mismatch"
+        ))
 }
 
 fn write_to_file(file_name: &str, content: &str, resource_type: &str) {


### PR DESCRIPTION
When we create device certificates, we first download the CA certificate from the application object, then use the private key provided by the user to sign the certificate. In this process, we didn't verify whether the private key provided was the correct one or not. 

In this PR using `x509-parser` crate we first verify that the public key in both the CA cert and private key should be the same, if not we throw a "Wrong CA Key" error.


