### PR TITLE
Added RSA key generation and algo parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "base64ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0d27fb6b6f1e43147af148af49d49329413ba781aa0d5e10979831c210173b5"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,7 +142,7 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.4",
 ]
 
 [[package]]
@@ -270,6 +276,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c32f031ea41b4291d695026c023b95d59db2d8a2c7640800ed56bc8f510f22"
+
+[[package]]
 name = "cookie"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,10 +383,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b32a398eb1ccfbe7e4f452bc749c44d38dd732e9a253f19da224c416f00ee7f4"
+dependencies = [
+ "generic-array 0.14.4",
+ "rand_core 0.6.2",
+ "subtle",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
+
+[[package]]
+name = "der"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f215f706081a44cb702c71c39a52c05da637822e9c1645a50b7202689e982d"
+dependencies = [
+ "const-oid",
+ "crypto-bigint",
+]
 
 [[package]]
 name = "der-oid-macro"
@@ -407,7 +440,16 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -445,8 +487,10 @@ dependencies = [
  "log",
  "oauth2",
  "qstring",
+ "rand 0.8.4",
  "rcgen",
  "reqwest 0.11.2",
+ "rsa",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -671,6 +715,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
 dependencies = [
  "typenum",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -985,6 +1039,9 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lexical-core"
@@ -1004,6 +1061,12 @@ name = "libc"
 version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56d855069fafbb9b344c0f962150cd2c1187975cb1c22c1522c240d8c4986714"
+
+[[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
 
 [[package]]
 name = "linked-hash-map"
@@ -1198,6 +1261,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4547ee5541c18742396ae2c895d0717d0f886d8823b8399cdaf7b07d63ad0480"
+dependencies = [
+ "autocfg 0.1.7",
+ "byteorder",
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.4",
+ "smallvec 1.6.1",
+ "zeroize",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1208,12 +1289,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg 1.0.1",
+ "libm",
 ]
 
 [[package]]
@@ -1327,7 +1420,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.1.57",
  "rustc_version",
- "smallvec",
+ "smallvec 0.6.14",
  "winapi 0.3.9",
 ]
 
@@ -1340,6 +1433,15 @@ dependencies = [
  "base64 0.13.0",
  "once_cell",
  "regex",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fe90c78c9a17442665a41a1a45dcd24bbab0e1794748edc19b27fffb146c13"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -1385,6 +1487,30 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "359e7852310174a810f078124edb73c66e88a1a731b2fd586dba34ee32dbe416"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee84ed13e44dd82689fa18348a49934fa79cc774a344c42fc9b301c71b140a"
+dependencies = [
+ "der",
+ "pem-rfc7468",
+ "pkcs1",
+ "spki",
+ "zeroize",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1478,9 +1604,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
@@ -1787,6 +1913,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c2603e2823634ab331437001b411b9ed11660fbc4066f3908c84a9439260d"
+dependencies = [
+ "byteorder",
+ "digest 0.9.0",
+ "lazy_static",
+ "num-bigint-dig",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand 0.8.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1950,7 +2096,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
 dependencies = [
  "block-buffer",
- "digest",
+ "digest 0.8.1",
  "fake-simd",
  "opaque-debug",
 ]
@@ -1983,6 +2129,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallvec"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
+
+[[package]]
 name = "socket2"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1997,6 +2149,15 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spki"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "987637c5ae6b3121aba9d513f869bd2bff11c4cc086c22473befd6649c0bd521"
+dependencies = [
+ "der",
+]
 
 [[package]]
 name = "static_assertions"
@@ -2036,6 +2197,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
@@ -2083,7 +2250,7 @@ checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "rand 0.8.3",
+ "rand 0.8.4",
  "redox_syscall 0.2.5",
  "remove_dir_all",
  "winapi 0.3.9",
@@ -2384,7 +2551,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09c8070a9942f5e7cfccd93f490fdebd230ee3c3c9f107cb25bad5351ef671cf"
 dependencies = [
- "smallvec",
+ "smallvec 0.6.14",
 ]
 
 [[package]]
@@ -2703,4 +2870,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
 dependencies = [
  "chrono",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377db0846015f7ae377174787dd452e1c5f5a9050bc6f954911d01f116daa0cd"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2c1e130bebaeab2f23886bf9acbaca14b092408c452543c857f66399cd6dab1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,6 @@ base64 = "0.13.0"
 rcgen = { version  = "0.8.11", features = ["pem", "x509-parser"] }
 x509-parser = "0.9.2"
 json_value_merge = "0.1.2"
+
+rsa = "0.5.0"
+rand = "0.8.4"

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -140,6 +140,7 @@ pub fn add_trust_anchor(
     config: &Context,
     app: &str,
     keyout: Option<&str>,
+    key_pair_algorithm: Option<&str>,
     days: Option<&str>,
 ) -> Result<()> {
     let res = get(config, &app);
@@ -148,7 +149,8 @@ pub fn add_trust_anchor(
             StatusCode::OK => {
                 let app_obj = r.text().unwrap_or_else(|_| "{}".to_string());
                 let mut app_obj: Value = serde_json::from_str(&app_obj)?;
-                app_obj["spec"]["trustAnchors"] = trust::create_trust_anchor(app, keyout, days)?;
+                app_obj["spec"]["trustAnchors"] =
+                    trust::create_trust_anchor(app, keyout, key_pair_algorithm, days)?;
 
                 put(config, app, app_obj)
                     .map(|p| util::print_result(p, format!("App {}", &app), Verbs::edit))

--- a/src/apps.rs
+++ b/src/apps.rs
@@ -140,7 +140,7 @@ pub fn add_trust_anchor(
     config: &Context,
     app: &str,
     keyout: Option<&str>,
-    key_pair_algorithm: Option<&str>,
+    key_pair_algorithm: Option<trust::SignAlgo>,
     days: Option<&str>,
 ) -> Result<()> {
     let res = get(config, &app);

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -248,7 +248,8 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .required(true)
         .help("Algorithm used to generate key pair.")
         .possible_value(trust::SignAlgo::ECDSA.as_ref())
-        .possible_value(trust::SignAlgo::EdDSA.as_ref());
+        .possible_value(trust::SignAlgo::EdDSA.as_ref())
+        .possible_value(trust::SignAlgo::RSA.as_ref());
 
     let key_pair_algorithm = algo_param
         .clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct Context {
     pub name: ContextId,
     pub drogue_cloud_url: Url,
     pub default_app: Option<AppId>,
+    pub default_algo: Option<String>,
     pub auth_url: Url,
     pub token_url: Url,
     pub registry_url: Url,
@@ -224,6 +225,10 @@ impl Context {
 
     pub fn set_default_app(&mut self, app: AppId) {
         self.default_app = Some(app);
+    }
+
+    pub fn set_default_algo(&mut self, algo: String) {
+        self.default_algo = Some(algo.to_string())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,5 @@
+use crate::trust::SignAlgo;
+
 use anyhow::{anyhow, Context as AnyhowContext, Result};
 use serde::{Deserialize, Serialize};
 use std::{env, fs::create_dir_all, fs::write, fs::File, path::Path, process::exit};
@@ -227,8 +229,10 @@ impl Context {
         self.default_app = Some(app);
     }
 
-    pub fn set_default_algo(&mut self, algo: String) {
-        self.default_algo = Some(algo.to_string())
+    pub fn set_default_algo(&mut self, algo: SignAlgo) {
+        self.default_algo = Some(match algo {
+            i => i.as_ref().to_string(),
+        })
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -230,9 +230,7 @@ impl Context {
     }
 
     pub fn set_default_algo(&mut self, algo: SignAlgo) {
-        self.default_algo = Some(match algo {
-            i => i.as_ref().to_string(),
-        })
+        self.default_algo = Some(algo.as_ref().to_string())
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,11 @@ fn main() -> Result<()> {
                 config.write(config_path)?;
             }
             Context_subcommands::set_default_algo => {
-                let algo = c.unwrap().value_of(&Parameters::algo).unwrap().to_string();
+                let algo = c
+                    .unwrap()
+                    .value_of(&Parameters::algo)
+                    .map(|a| trust::SignAlgo::from_str(a).unwrap())
+                    .unwrap();
                 let context = config.get_context_mut(&ctx_id)?;
 
                 context.set_default_algo(algo);
@@ -137,12 +141,16 @@ fn main() -> Result<()> {
         let verb = Trust_subcommands::from_str(v);
         let app_id = arguments::get_app_id(&command.unwrap(), &context)?;
         let days = command.unwrap().value_of(&Parameters::days);
-        let key_pair_algorithm = command.unwrap().value_of(&Parameters::algo).or_else(|| {
-            context.default_algo.as_deref().map(|a| {
-                println!("Using default signature algorithm: {}", a);
-                a
+        let key_pair_algorithm = command
+            .unwrap()
+            .value_of(&Parameters::algo)
+            .or_else(|| {
+                context.default_algo.as_deref().map(|a| {
+                    println!("Using default signature algorithm: {}", a);
+                    a
+                })
             })
-        });
+            .map(|algo| trust::SignAlgo::from_str(algo).unwrap());
 
         match verb? {
             Trust_subcommands::create => {

--- a/src/openid.rs
+++ b/src/openid.rs
@@ -48,6 +48,7 @@ pub fn login(
         name: context_name,
         drogue_cloud_url: api_endpoint,
         default_app: None,
+        default_algo: None,
         token,
         token_url,
         auth_url,

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -8,7 +8,7 @@ use rcgen::{
 use serde_json::{json, Value};
 use std::fs::File;
 use std::io::Write;
-use std::{fs, process::exit, str::from_utf8, str::FromStr};
+use std::{fs, process::exit, str::from_utf8};
 use strum_macros::{AsRefStr, EnumString};
 
 pub const CERT_VALIDITY_DAYS: i64 = 365;
@@ -29,7 +29,7 @@ fn generate_certificate(
     cert_type: CertificateType,
     common_name: &str,
     organizational_unit: &str,
-    key_pair_algorithm: Option<&str>,
+    key_pair_algorithm: Option<SignAlgo>,
     days: Option<&str>,
 ) -> Result<Certificate> {
     let mut params = CertificateParams::new(vec!["Drogue Iot".to_owned()]);
@@ -53,7 +53,7 @@ fn generate_certificate(
         .push(DnType::CommonName, common_name.to_owned());
 
     params.alg = match key_pair_algorithm {
-        Some(algo_name) => match SignAlgo::from_str(algo_name)? {
+        Some(algo_name) => match algo_name {
             SignAlgo::ECDSA => &PKCS_ECDSA_P256_SHA256,
             SignAlgo::EdDSA => &PKCS_ED25519,
         },
@@ -82,7 +82,7 @@ fn generate_certificate(
 pub fn create_trust_anchor(
     app_id: &str,
     keyout: Option<&str>,
-    key_pair_algorithm: Option<&str>,
+    key_pair_algorithm: Option<SignAlgo>,
     days: Option<&str>,
 ) -> Result<Value> {
     const OU: &str = "Cloud";
@@ -120,7 +120,7 @@ pub fn create_device_certificate(
     ca_cert: &str,
     cert_key: Option<&str>,
     cert_out: Option<&str>,
-    key_pair_algorithm: Option<&str>,
+    key_pair_algorithm: Option<SignAlgo>,
     days: Option<&str>,
 ) -> Result<()> {
     let ca_key_content = KeyPair::from_pem(&read_from_file(ca_key))


### PR DESCRIPTION
While creating trust anchors and device certificates this parameter helps specify a signature algorithm.
`drg trust add --device <device_name> --ca-key <key.pem> --algo ECDSA`

Users can also save a default algorithm choice to the context file, in the following manner.
`drg context set-default-algo ECDSA`

Currently, there are 3 possible values for `algo` parameter
- `ECDSA`
- `EdDSA`
- `RSA`

Initially `trust` commands look for specifying `algo` parameter, if it is absent current config file is searched for a default choice, if that is not present as well, `ECDSA` is used.
