### PR TITLE
Tweaked trust commands

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -99,7 +99,7 @@ pub enum Context_subcommands {
 #[allow(non_camel_case_types)]
 pub enum Trust_subcommands {
     create,
-    add,
+    enroll,
 }
 
 #[derive(AsRefStr, EnumString)]
@@ -230,13 +230,6 @@ pub fn parse_arguments() -> ArgMatches<'static> {
         .required(false)
         .long(Parameters::key_output.as_ref())
         .help("Generate and Output file containing the private key. Later to be used to sign device certificates, or device authentication.");
-
-    let device_id_flag = Arg::with_name(&Resources::device.as_ref())
-        .short("d")
-        .required(true)
-        .long(&Resources::device.as_ref())
-        .takes_value(true)
-        .help("Device id");
 
     let ca_key = Arg::with_name(&Parameters::ca_key.as_ref())
         .long(&Parameters::ca_key.as_ref())
@@ -512,17 +505,17 @@ pub fn parse_arguments() -> ArgMatches<'static> {
                 .subcommand(
                     SubCommand::with_name(Trust_subcommands::create.as_ref())
                         .about("Create a trust-anchor for an application.")
-                        .arg(&app_id_arg)
+                        .arg(&resource_id_arg.clone().required(false))
                         .arg(&keyout)
                         .arg(&key_pair_algorithm)
                         .arg(&cert_valid_days)
                         .arg(&key_input),
                 )
                 .subcommand(
-                    SubCommand::with_name(Trust_subcommands::add.as_ref())
+                    SubCommand::with_name(Trust_subcommands::enroll.as_ref())
                         .about("Signs device certificate using application's private key.")
+                        .arg(&resource_id_arg)
                         .arg(&app_id_arg)
-                        .arg(&device_id_flag)
                         .arg(&ca_key)
                         .arg(&cert_out)
                         .arg(&keyout)


### PR DESCRIPTION
This PR changes
- `drg trust add --device d1` to `drg trust enroll d1` dropping the device flag.
- `drg trust create --app app1` to `drg trust create app1` dropping the app flag. 
