### PR TITLE
[feat] Add support for multiple operations in standard and JSON output

### DIFF
--- a/src/admin/transfer.rs
+++ b/src/admin/transfer.rs
@@ -56,7 +56,7 @@ pub async fn accept_transfer(config: &Context, app: &str) -> Result<Outcome<Stri
     )
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct AppTransfer {
     console: Option<Url>,
     app: String,

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -28,27 +28,36 @@ pub async fn apply(
     config: &Context,
     paths: Vec<&PathBuf>,
     ignore_resource_version: bool,
-) -> Result<Outcome<String>, DrogueError> {
+) -> Vec<Result<Outcome<String>, DrogueError>> {
     let mut resources: Vec<Resource> = Vec::new();
+    let mut results: Vec<Result<Outcome<String>, DrogueError>> = Vec::new();
 
     // explore directories and load every file there
     for p in paths {
         if p.is_dir() {
-            for file in read_dir(p)? {
-                match load_json(&file.unwrap().path()) {
-                    Ok(r) => resources.push(r),
-                    Err(e) => log::error!("{e}"),
+            match read_dir(p) {
+                Err(e) => results.push(Err(InvalidInput(e.to_string()))),
+                Ok(files) => {
+                    for file in files {
+                        match load_json(&file.unwrap().path()) {
+                            Ok(r) => resources.push(r),
+                            Err(e) => results.push(Err(e)),
+                        }
+                    }
                 }
             }
         } else if p == &PathBuf::from("-") {
             match std_in() {
                 Ok(r) => resources.push(r),
-                Err(e) => log::error!("{e}"),
+                Err(e) => results.push(Err(e)),
             }
         } else {
             match load_json(p) {
                 Ok(r) => resources.push(r),
-                Err(e) => log::error!("Cannot read file {:?} -> {e}", p),
+                Err(e) => results.push(Err(InvalidInput(format!(
+                    "Cannot read file {:?} -> {e}",
+                    p
+                )))),
             }
         }
     }
@@ -56,79 +65,59 @@ pub async fn apply(
     for mut r in resources {
         match r {
             Resource::Device(ref mut dev) => {
-                match check_existence(
-                    config,
-                    ResourceName::Device(
-                        dev.metadata.application.clone(),
-                        dev.metadata.name.clone(),
-                    ),
-                )
-                .await?
-                {
-                    ExistenceOutcome::Update => {
-                        if ignore_resource_version {
-                            // an empty string will skip the field serialization
-                            dev.metadata.resource_version = String::default();
-                        }
-                        match DeviceOperation::from_device(dev.clone()).edit(config).await {
-                            Ok(_) => {
-                                println!("Success updating device {}", dev.metadata.name.clone())
-                            }
-                            Err(e) => println!("Error updating device {}: {e}", dev.metadata.name),
-                        }
-                    }
-                    ExistenceOutcome::Create => {
-                        match DeviceOperation::from_device(dev.clone())
-                            .create(config)
-                            .await
-                        {
-                            Ok(_) => {
-                                println!("Success creating device {}", dev.metadata.name.clone())
-                            }
-                            Err(e) => println!("Error creating device {}: {e}", dev.metadata.name),
-                        }
-                    }
-                    ExistenceOutcome::NoApp => log::error!(
-                        "Cannot apply device {} : application {} does not exist",
-                        dev.metadata.name,
-                        dev.metadata.application
-                    ),
+                if ignore_resource_version {
+                    // an empty string will skip the field serialization
+                    dev.metadata.resource_version = String::default();
                 }
+                results.push(apply_device(config, dev).await);
             }
             Resource::Application(ref mut app) => {
-                match check_existence(config, ResourceName::Application(app.metadata.name.clone()))
-                    .await?
-                {
-                    ExistenceOutcome::Update => {
-                        if ignore_resource_version {
-                            // an empty string will skip the field serialization
-                            app.metadata.resource_version = String::default();
-                        }
-                        match ApplicationOperation::from_application(app.clone())
-                            .edit(config)
-                            .await
-                        {
-                            Ok(_) => println!("Success updating app {}", app.metadata.name.clone()),
-                            Err(e) => println!("Error updating app {}: {e}", app.metadata.name),
-                        }
-                    }
-                    ExistenceOutcome::Create => {
-                        match ApplicationOperation::from_application(app.clone())
-                            .create(config)
-                            .await
-                        {
-                            Ok(_) => println!("Success creating app {}", app.metadata.name.clone()),
-                            Err(e) => println!("Error creating app {}: {e}", app.metadata.name),
-                        }
-                    }
-                    ExistenceOutcome::NoApp => unreachable!(),
+                if ignore_resource_version {
+                    // an empty string will skip the field serialization
+                    app.metadata.resource_version = String::default();
                 }
+                results.push(apply_app(config, app).await);
             }
         }
     }
 
-    //fixme drg don't really handles multiple operations yet :)
-    Ok(Outcome::SuccessWithMessage("Finished apply".to_string()))
+    results
+}
+
+async fn apply_device(config: &Context, dev: &Device) -> Result<Outcome<String>, DrogueError> {
+    match check_existence(
+        config,
+        ResourceName::Device(dev.metadata.application.clone(), dev.metadata.name.clone()),
+    )
+    .await?
+    {
+        ExistenceOutcome::Update => DeviceOperation::from_device(dev.clone()).edit(config).await,
+        ExistenceOutcome::Create => {
+            DeviceOperation::from_device(dev.clone())
+                .create(config)
+                .await
+        }
+        ExistenceOutcome::NoApp => Err(InvalidInput(format!(
+            "Cannot apply device {} : application {} does not exist",
+            dev.metadata.name, dev.metadata.application
+        ))),
+    }
+}
+
+async fn apply_app(config: &Context, app: &Application) -> Result<Outcome<String>, DrogueError> {
+    match check_existence(config, ResourceName::Application(app.metadata.name.clone())).await? {
+        ExistenceOutcome::Update => {
+            ApplicationOperation::from_application(app.clone())
+                .edit(config)
+                .await
+        }
+        ExistenceOutcome::Create => {
+            ApplicationOperation::from_application(app.clone())
+                .create(config)
+                .await
+        }
+        ExistenceOutcome::NoApp => unreachable!(),
+    }
 }
 
 fn std_in() -> Result<Resource, DrogueError> {
@@ -157,12 +146,18 @@ fn load_json(path: &PathBuf) -> Result<Resource, DrogueError> {
 }
 
 fn deser(json: Value) -> Result<Resource, DrogueError> {
-    if json.get("metadata").unwrap().get("application").is_some() {
-        let dev: Device = serde_json::from_value(json)?;
-        Ok(Resource::Device(dev))
+    if let Some(metadata) = json.get("metadata") {
+        if metadata.get("application").is_some() {
+            let dev: Device = serde_json::from_value(json)?;
+            Ok(Resource::Device(dev))
+        } else {
+            let app: Application = serde_json::from_value(json)?;
+            Ok(Resource::Application(app))
+        }
     } else {
-        let app: Application = serde_json::from_value(json)?;
-        Ok(Resource::Application(app))
+        Err(DrogueError::InvalidInput(
+            "Input data does not represent a valid drogue resource".to_string(),
+        ))
     }
 }
 
@@ -179,7 +174,7 @@ async fn check_existence(
                 // 404 response, let's try if the app even exist
                 Err(DrogueError::NotFound) => {
                     log::info!(
-                        "Device {} does not exist, verify if application {} exists.",
+                        "Device {} does not exist, verifying if application {} exists.",
                         &dev,
                         &app
                     );

--- a/src/arguments/config.rs
+++ b/src/arguments/config.rs
@@ -34,9 +34,11 @@ pub fn subcommand(
 
                 display(c, json, |c| println!("{}", c))
             } else {
-                display(Ok(Outcome::SuccessWithJsonData(config)), json, |c| {
-                    println!("{}", c)
-                })
+                display(
+                    Ok(Outcome::SuccessWithJsonData(config.clone())),
+                    json,
+                    |c| println!("{}", c),
+                )
             }
         }
         "default-context" => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ use oauth2::TokenResponse;
 use tabular::{Row, Table};
 use url::Url;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Config {
     pub active_context: String,
     pub contexts: Vec<Context>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,9 @@ use crate::admin::tokens;
 use crate::applications::ApplicationOperation;
 use crate::config::{AccessToken, Config, Context};
 use crate::devices::DeviceOperation;
-use crate::util::{display, display_simple, DrogueError, Outcome};
+use crate::util::{
+    display, display_multiple, display_simple, DrogueError, MultipleOutcomes, Outcome,
+};
 
 use anyhow::{Context as AnyhowContext, Result};
 use clap::ArgMatches;
@@ -257,7 +259,8 @@ async fn process_arguments(matches: ArgMatches) -> Result<i32> {
             let ignore_version = matches.get_flag(Parameters::ignore_conflict.as_ref());
 
             let res = apply::apply(context, path, ignore_version).await;
-            display_simple(res, json_output)?
+            let res = MultipleOutcomes::from(res);
+            display_multiple(res, json_output)?
         }
 
         Action::label => {

--- a/src/util/display.rs
+++ b/src/util/display.rs
@@ -1,4 +1,5 @@
-use crate::util::{show_json, show_json_string, DrogueError, JsonOutcome, Outcome};
+use crate::util::{show_json, show_json_string, DrogueError, JsonOutcome, Outcome, OutcomeStatus};
+use crate::MultipleOutcomes;
 use serde::Serialize;
 
 pub fn display<T, F>(
@@ -7,7 +8,7 @@ pub fn display<T, F>(
     f_data: F,
 ) -> anyhow::Result<i32>
 where
-    T: Serialize,
+    T: Serialize + Clone,
     F: FnOnce(&T),
 {
     match (outcome, json) {
@@ -34,11 +35,64 @@ where
 }
 
 /// fallback to showing the serialized object
-pub fn display_simple<T: Serialize>(
+pub fn display_simple<T: Serialize + Clone>(
     outcome: Result<Outcome<T>, DrogueError>,
     json: bool,
 ) -> anyhow::Result<i32> {
     display(outcome, json, |data: &T| {
         show_json_string(serde_json::to_string(data).unwrap())
     })
+}
+
+pub fn display_multiple<T: Serialize + Clone>(
+    outcomes: MultipleOutcomes<T>,
+    json: bool,
+) -> anyhow::Result<i32> {
+    if outcomes.operations.len() == 1 {
+        // This is ugly but i can't derive clone for Result<Outome, DrogueError>
+        let outcome = match outcomes.operations.get(0).unwrap() {
+            Ok(o) => Ok(o.clone()),
+            Err(e) => Err(e.clone()),
+        };
+        return display_simple(outcome, json);
+    } else if json {
+        let jsons: Vec<JsonOutcome> = outcomes
+            .operations
+            .iter()
+            .map(|r| match r {
+                Ok(outcome) => JsonOutcome::from(outcome),
+                Err(e) => JsonOutcome::from(e),
+            })
+            .collect();
+
+        let outcome = JsonOutcome {
+            status: outcomes.status,
+            message: outcomes.message,
+            http_status: None,
+            operations: Some(jsons),
+        };
+
+        show_json(&serde_json::to_value(&outcome)?);
+        match outcomes.status {
+            OutcomeStatus::Success => Ok(0),
+            OutcomeStatus::Failure => Ok(1),
+        }
+    } else {
+        println!("{}", outcomes.message);
+        for result in outcomes.operations {
+            match result {
+                Ok(success) => match success {
+                    Outcome::SuccessWithMessage(msg) => println!("{msg}"),
+                    Outcome::SuccessWithJsonData(data) => unreachable!(),
+                },
+                Err(e) => {
+                    println!("{}", e);
+                }
+            }
+        }
+        match outcomes.status {
+            OutcomeStatus::Success => Ok(0),
+            OutcomeStatus::Failure => Ok(1),
+        }
+    }
 }

--- a/src/util/error.rs
+++ b/src/util/error.rs
@@ -53,3 +53,17 @@ impl From<std::io::Error> for DrogueError {
         DrogueError::InvalidInput(format!("Filesystem error: {}", e))
     }
 }
+
+impl Clone for DrogueError {
+    fn clone(&self) -> Self {
+        match self {
+            DrogueError::InvalidInput(msg) => DrogueError::InvalidInput(msg.clone()),
+            DrogueError::NotFound => DrogueError::NotFound,
+            DrogueError::Service(msg, code) => DrogueError::Service(msg.clone(), code.clone()),
+            DrogueError::UnexpectedClient(e) => {
+                DrogueError::UnexpectedClient(anyhow!(e.to_string()))
+            }
+            DrogueError::ConfigIssue(msg) => DrogueError::ConfigIssue(msg.clone()),
+        }
+    }
+}

--- a/src/util/outcome.rs
+++ b/src/util/outcome.rs
@@ -1,33 +1,32 @@
 use crate::util::error::DrogueError;
 use serde::{Deserialize, Serialize};
 
-pub enum Outcome<T: Serialize> {
+#[derive(Clone)]
+pub enum Outcome<T: Serialize + Clone> {
     SuccessWithMessage(String),
     SuccessWithJsonData(T),
 }
 
-// impl<T: Serialize> Outcome<T> {
-//     pub fn inner(self) -> Result<T, DrogueError> {
-//         match self {
-//             Outcome::SuccessWithJsonData(t) => Ok(t),
-//             // todo add a drogueError variant for this type of stuff ?
-//             Outcome::SuccessWithMessage(msg) => Err(DrogueError::InvalidInput(msg)),
-//         }
-//     }
-// }
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct JsonOutcome {
-    status: OutcomeStatus,
-    message: String,
-    // The HTTP status code
-    #[serde(skip_serializing_if = "Option::is_none")]
-    http_status: Option<u16>,
+pub struct MultipleOutcomes<T: Serialize + Clone> {
+    pub status: OutcomeStatus,
+    pub message: String,
+    pub operations: Vec<Result<Outcome<T>, DrogueError>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+pub struct JsonOutcome {
+    pub status: OutcomeStatus,
+    pub message: String,
+    // The HTTP status code
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operations: Option<Vec<JsonOutcome>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Copy, Clone)]
 #[serde(rename_all = "lowercase")]
-enum OutcomeStatus {
+pub enum OutcomeStatus {
     Success,
     Failure,
 }
@@ -39,11 +38,13 @@ impl From<&DrogueError> for JsonOutcome {
                 status: OutcomeStatus::Failure,
                 message: error.to_string(),
                 http_status: Some(404),
+                operations: None,
             },
             DrogueError::Service(e, status) => JsonOutcome {
                 status: OutcomeStatus::Failure,
                 message: e.clone(),
                 http_status: Some(*status),
+                operations: None,
             },
             DrogueError::InvalidInput(e) => JsonOutcome::failure(e.clone()),
             DrogueError::UnexpectedClient(e) => {
@@ -54,12 +55,22 @@ impl From<&DrogueError> for JsonOutcome {
     }
 }
 
+impl<T: Serialize + Clone> From<&Outcome<T>> for JsonOutcome {
+    fn from(outcome: &Outcome<T>) -> Self {
+        match outcome {
+            Outcome::SuccessWithMessage(msg) => JsonOutcome::success(msg.clone()),
+            Outcome::SuccessWithJsonData(_) => unreachable!(),
+        }
+    }
+}
+
 impl JsonOutcome {
     pub fn success(message: String) -> JsonOutcome {
         JsonOutcome {
             status: OutcomeStatus::Success,
             message,
             http_status: None,
+            operations: None,
         }
     }
 
@@ -68,6 +79,32 @@ impl JsonOutcome {
             status: OutcomeStatus::Failure,
             message,
             http_status: None,
+            operations: None,
         }
+    }
+}
+
+impl<T: Serialize + Clone> From<Vec<Result<Outcome<T>, DrogueError>>> for MultipleOutcomes<T> {
+    fn from(results: Vec<Result<Outcome<T>, DrogueError>>) -> Self {
+        let mut status = OutcomeStatus::Success;
+
+        let _ = results.iter().map(|r| {
+            if r.is_err() {
+                status = OutcomeStatus::Failure
+            }
+        });
+
+        MultipleOutcomes {
+            status,
+            message: String::new(),
+            operations: results,
+        }
+    }
+}
+
+impl<T: Serialize + Clone> MultipleOutcomes<T> {
+    pub fn message(mut self, msg: String) -> Self {
+        self.message = msg;
+        self
     }
 }

--- a/test-utils/src/outcome.rs
+++ b/test-utils/src/outcome.rs
@@ -11,7 +11,7 @@ pub struct JsonOutcome {
     pub http_status: Option<u16>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum OutcomeStatus {
     Success,


### PR DESCRIPTION
TODO : 

- [ ] add support in `create`
- [ ] add support in `read`
- [ ] add support in `delete`
- [ ] Use that to clean up the output of the certs subcommand
- [ ] **issue** Multiple ops marked as success when one is failed
