### PR TITLE
Fix "typo" in config_file_arg help message

### DIFF
--- a/src/arguments/cli.rs
+++ b/src/arguments/cli.rs
@@ -686,7 +686,7 @@ pub fn app_arguments() -> clap::Command<'static> {
         .takes_value(true)
         .global(true)
         .value_name("FILE")
-        .help("Path to the drgconfig file. If not specified, reads $DRGCFG environment variable or defaults to XDG config directory for drg_config.json");
+        .help("Path to the drg config file. If not specified, reads $DRGCFG environment variable or defaults to XDG config directory for drg_config.json");
 
     let verbose = Arg::new(Parameters::verbose.as_ref())
         .short('v')


### PR DESCRIPTION
This commit updates the help message for the --config option which currently looks like this:
```console
$ drg get --help
...
-C, --config <FILE> Path to the drgconfig file. If not specified,
                    reads $DRGCFG environment variable or defaults
                    to XDG config directory for drg_config.json
```
I was not sure if `drgconfig` was a typo or not, so opening a PR just in case.

Signed-off-by: Daniel Bevenius <daniel.bevenius@gmail.com>